### PR TITLE
Add "OTHER" to license list

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const spdxExpressionParse = require('spdx-expression-parse')
 const spdxSatisfies = require('spdx-satisfies')
 const spdxLicenseList = require('spdx-license-list')
 const spdxLicenseSet = require('spdx-license-list/simple')
+spdxLicenseSet.add('OTHER') // OTHER is a valid license in Clearly Defined, not found in SPDX
+
 const lowerSpdxLicenseMap = new Map(Array.from(spdxLicenseSet).map(x => [x.toLowerCase(), x]))
 const lowerSpdxNameMap = new Map(Object.keys(spdxLicenseList).map(x => [spdxLicenseList[x].name.toLowerCase(), x]))
 const { isEqual, sortBy, union, uniqWith } = require('lodash')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearlydefined/spdx",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "SPDX custom libraries of clearlydefined.io.",
   "license": "MIT",
   "repository": {

--- a/test.js
+++ b/test.js
@@ -7,51 +7,52 @@ const { expect } = require('chai')
 describe('SPDX utility functions', () => {
   it('parses spdx expressions', () => {
     const data = new Map([
-      [{ license: 'MIT' }, { license: 'MIT' }],
-      ['MIT', { license: 'MIT' }],
-      ['mit', { license: 'MIT' }],
-      ['MIT ', { license: 'MIT' }],
-      [' MIT', { license: 'MIT' }],
-      ['MIT OR Apache-2.0', { left: { license: 'MIT' }, conjunction: 'or', right: { license: 'Apache-2.0' } }],
-      ['MIT AND Apache-2.0', { left: { license: 'MIT' }, conjunction: 'and', right: { license: 'Apache-2.0' } }],
-      [
-        'MIT OR (BSD-2-Clause AND GPL-2.0)',
-        {
-          left: { license: 'MIT' },
-          conjunction: 'or',
-          right: { left: { license: 'BSD-2-Clause' }, conjunction: 'and', right: { license: 'GPL-2.0' } }
-        }
-      ],
-      [
-        'MIT OR BSD-2-Clause OR (BSD-3-Clause AND Unlicense)',
-        {
-          left: { license: 'MIT' },
-          conjunction: 'or',
-          right: {
-            left: { license: 'BSD-2-Clause' },
-            conjunction: 'or',
-            right: { left: { license: 'BSD-3-Clause' }, conjunction: 'and', right: { license: 'Unlicense' } }
-          }
-        }
-      ],
-      [
-        'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR (CC-BY-4.0 AND Apache-2.0)',
-        {
-          left: {
-            left: { license: 'MIT' },
-            conjunction: 'and',
-            right: { license: 'BSD-3-Clause', exception: 'GCC-exception-3.1' }
-          },
-          conjunction: 'or',
-          right: {
-            left: { license: 'CC-BY-4.0' },
-            conjunction: 'and',
-            right: { license: 'Apache-2.0' }
-          }
-        }
-      ],
-      ['Apache-2.0 WITH Autoconf-exception-2.0', { license: 'Apache-2.0', exception: 'Autoconf-exception-2.0' }],
-      ['Apache-2.0 WITH commons-clause', { license: 'Apache-2.0', exception: 'NOASSERTION' }]
+      // [{ license: 'MIT' }, { license: 'MIT' }],
+      // ['MIT', { license: 'MIT' }],
+      // ['mit', { license: 'MIT' }],
+      // ['MIT ', { license: 'MIT' }],
+      // [' MIT', { license: 'MIT' }],
+      ['Other', { license: 'OTHER' }],
+      // ['MIT OR Apache-2.0', { left: { license: 'MIT' }, conjunction: 'or', right: { license: 'Apache-2.0' } }],
+      // ['MIT AND Apache-2.0', { left: { license: 'MIT' }, conjunction: 'and', right: { license: 'Apache-2.0' } }],
+      // [
+      //   'MIT OR (BSD-2-Clause AND GPL-2.0)',
+      //   {
+      //     left: { license: 'MIT' },
+      //     conjunction: 'or',
+      //     right: { left: { license: 'BSD-2-Clause' }, conjunction: 'and', right: { license: 'GPL-2.0' } }
+      //   }
+      // ],
+      // [
+      //   'MIT OR BSD-2-Clause OR (BSD-3-Clause AND Unlicense)',
+      //   {
+      //     left: { license: 'MIT' },
+      //     conjunction: 'or',
+      //     right: {
+      //       left: { license: 'BSD-2-Clause' },
+      //       conjunction: 'or',
+      //       right: { left: { license: 'BSD-3-Clause' }, conjunction: 'and', right: { license: 'Unlicense' } }
+      //     }
+      //   }
+      // ],
+      // [
+      //   'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR (CC-BY-4.0 AND Apache-2.0)',
+      //   {
+      //     left: {
+      //       left: { license: 'MIT' },
+      //       conjunction: 'and',
+      //       right: { license: 'BSD-3-Clause', exception: 'GCC-exception-3.1' }
+      //     },
+      //     conjunction: 'or',
+      //     right: {
+      //       left: { license: 'CC-BY-4.0' },
+      //       conjunction: 'and',
+      //       right: { license: 'Apache-2.0' }
+      //     }
+      //   }
+      // ],
+      // ['Apache-2.0 WITH Autoconf-exception-2.0', { license: 'Apache-2.0', exception: 'Autoconf-exception-2.0' }],
+      // ['Apache-2.0 WITH commons-clause', { license: 'Apache-2.0', exception: 'NOASSERTION' }]
     ])
 
     data.forEach((expected, input) => {
@@ -190,30 +191,32 @@ describe('SPDX utility functions', () => {
   it('normalizes spdx expressions', () => {
     // prettier-ignore
     const data = {
-      'AGPL-1.0': 'AGPL-1.0',
-      'apache-2.0': 'Apache-2.0',
-      'apache2': 'NOASSERTION',
-      'GPL-': 'NOASSERTION',
-      'GPL-2.0-with-autoconf-exception': 'GPL-2.0-with-autoconf-exception',
-      'GPL-3.0': 'GPL-3.0',
-      'GPL': 'NOASSERTION',
-      'mit': 'MIT',
-      'MIT ': 'MIT',
-      ' MIT': 'MIT',
-      'GPL-1.0+': 'GPL-1.0+',
-      'Apache-2.0 WITH commons-clause': 'NOASSERTION',
-      'NOASSERTION': 'NOASSERTION',
-      'See license': 'NOASSERTION',
-      'MIT OR Apache-2.0': 'MIT OR Apache-2.0',
-      'MIT AND LGPL-2.1+ AND BSD-3-Clause': 'MIT AND LGPL-2.1+ AND BSD-3-Clause',
-      '(MIT AND BSD-3-Clause WITH GCC-exception-3.1) OR (CC-BY-4.0 AND Apache-2.0)': 'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR CC-BY-4.0 AND Apache-2.0',
-      'MIT AND BSD-3-Clause AND CC-BY-4.0': 'MIT AND BSD-3-Clause AND CC-BY-4.0',
-      'MIT OR Junk': 'MIT OR NOASSERTION',
-      'mit OR Junk': 'MIT OR NOASSERTION',
-      'Commercial AND Apache-2.0': 'NOASSERTION AND Apache-2.0',
-      'Junk1 OR Junk 2': 'NOASSERTION',
-      ' ': null,
-      null: null
+      // 'AGPL-1.0': 'AGPL-1.0',
+      // 'apache-2.0': 'Apache-2.0',
+      // 'apache2': 'NOASSERTION',
+      // 'GPL-': 'NOASSERTION',
+      // 'GPL-2.0-with-autoconf-exception': 'GPL-2.0-with-autoconf-exception',
+      // 'GPL-3.0': 'GPL-3.0',
+      // 'GPL': 'NOASSERTION',
+      // 'mit': 'MIT',
+      // 'MIT ': 'MIT',
+      // ' MIT': 'MIT',
+      // 'GPL-1.0+': 'GPL-1.0+',
+      'OTHER': 'OTHER',
+      'other': 'OTHER',
+      // 'Apache-2.0 WITH commons-clause': 'NOASSERTION',
+      // 'NOASSERTION': 'NOASSERTION',
+      // 'See license': 'NOASSERTION',
+      // 'MIT OR Apache-2.0': 'MIT OR Apache-2.0',
+      // 'MIT AND LGPL-2.1+ AND BSD-3-Clause': 'MIT AND LGPL-2.1+ AND BSD-3-Clause',
+      // '(MIT AND BSD-3-Clause WITH GCC-exception-3.1) OR (CC-BY-4.0 AND Apache-2.0)': 'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR CC-BY-4.0 AND Apache-2.0',
+      // 'MIT AND BSD-3-Clause AND CC-BY-4.0': 'MIT AND BSD-3-Clause AND CC-BY-4.0',
+      // 'MIT OR Junk': 'MIT OR NOASSERTION',
+      // 'mit OR Junk': 'MIT OR NOASSERTION',
+      // 'Commercial AND Apache-2.0': 'NOASSERTION AND Apache-2.0',
+      // 'Junk1 OR Junk 2': 'NOASSERTION',
+      // ' ': null,
+      // null: null
     }
     for (let input of Object.keys(data)) {
       if (input === 'null') input = null

--- a/test.js
+++ b/test.js
@@ -7,52 +7,52 @@ const { expect } = require('chai')
 describe('SPDX utility functions', () => {
   it('parses spdx expressions', () => {
     const data = new Map([
-      // [{ license: 'MIT' }, { license: 'MIT' }],
-      // ['MIT', { license: 'MIT' }],
-      // ['mit', { license: 'MIT' }],
-      // ['MIT ', { license: 'MIT' }],
-      // [' MIT', { license: 'MIT' }],
+      [{ license: 'MIT' }, { license: 'MIT' }],
+      ['MIT', { license: 'MIT' }],
+      ['mit', { license: 'MIT' }],
+      ['MIT ', { license: 'MIT' }],
+      [' MIT', { license: 'MIT' }],
       ['Other', { license: 'OTHER' }],
-      // ['MIT OR Apache-2.0', { left: { license: 'MIT' }, conjunction: 'or', right: { license: 'Apache-2.0' } }],
-      // ['MIT AND Apache-2.0', { left: { license: 'MIT' }, conjunction: 'and', right: { license: 'Apache-2.0' } }],
-      // [
-      //   'MIT OR (BSD-2-Clause AND GPL-2.0)',
-      //   {
-      //     left: { license: 'MIT' },
-      //     conjunction: 'or',
-      //     right: { left: { license: 'BSD-2-Clause' }, conjunction: 'and', right: { license: 'GPL-2.0' } }
-      //   }
-      // ],
-      // [
-      //   'MIT OR BSD-2-Clause OR (BSD-3-Clause AND Unlicense)',
-      //   {
-      //     left: { license: 'MIT' },
-      //     conjunction: 'or',
-      //     right: {
-      //       left: { license: 'BSD-2-Clause' },
-      //       conjunction: 'or',
-      //       right: { left: { license: 'BSD-3-Clause' }, conjunction: 'and', right: { license: 'Unlicense' } }
-      //     }
-      //   }
-      // ],
-      // [
-      //   'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR (CC-BY-4.0 AND Apache-2.0)',
-      //   {
-      //     left: {
-      //       left: { license: 'MIT' },
-      //       conjunction: 'and',
-      //       right: { license: 'BSD-3-Clause', exception: 'GCC-exception-3.1' }
-      //     },
-      //     conjunction: 'or',
-      //     right: {
-      //       left: { license: 'CC-BY-4.0' },
-      //       conjunction: 'and',
-      //       right: { license: 'Apache-2.0' }
-      //     }
-      //   }
-      // ],
-      // ['Apache-2.0 WITH Autoconf-exception-2.0', { license: 'Apache-2.0', exception: 'Autoconf-exception-2.0' }],
-      // ['Apache-2.0 WITH commons-clause', { license: 'Apache-2.0', exception: 'NOASSERTION' }]
+      ['MIT OR Apache-2.0', { left: { license: 'MIT' }, conjunction: 'or', right: { license: 'Apache-2.0' } }],
+      ['MIT AND Apache-2.0', { left: { license: 'MIT' }, conjunction: 'and', right: { license: 'Apache-2.0' } }],
+      [
+        'MIT OR (BSD-2-Clause AND GPL-2.0)',
+        {
+          left: { license: 'MIT' },
+          conjunction: 'or',
+          right: { left: { license: 'BSD-2-Clause' }, conjunction: 'and', right: { license: 'GPL-2.0' } }
+        }
+      ],
+      [
+        'MIT OR BSD-2-Clause OR (BSD-3-Clause AND Unlicense)',
+        {
+          left: { license: 'MIT' },
+          conjunction: 'or',
+          right: {
+            left: { license: 'BSD-2-Clause' },
+            conjunction: 'or',
+            right: { left: { license: 'BSD-3-Clause' }, conjunction: 'and', right: { license: 'Unlicense' } }
+          }
+        }
+      ],
+      [
+        'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR (CC-BY-4.0 AND Apache-2.0)',
+        {
+          left: {
+            left: { license: 'MIT' },
+            conjunction: 'and',
+            right: { license: 'BSD-3-Clause', exception: 'GCC-exception-3.1' }
+          },
+          conjunction: 'or',
+          right: {
+            left: { license: 'CC-BY-4.0' },
+            conjunction: 'and',
+            right: { license: 'Apache-2.0' }
+          }
+        }
+      ],
+      ['Apache-2.0 WITH Autoconf-exception-2.0', { license: 'Apache-2.0', exception: 'Autoconf-exception-2.0' }],
+      ['Apache-2.0 WITH commons-clause', { license: 'Apache-2.0', exception: 'NOASSERTION' }]
     ])
 
     data.forEach((expected, input) => {
@@ -191,32 +191,32 @@ describe('SPDX utility functions', () => {
   it('normalizes spdx expressions', () => {
     // prettier-ignore
     const data = {
-      // 'AGPL-1.0': 'AGPL-1.0',
-      // 'apache-2.0': 'Apache-2.0',
-      // 'apache2': 'NOASSERTION',
-      // 'GPL-': 'NOASSERTION',
-      // 'GPL-2.0-with-autoconf-exception': 'GPL-2.0-with-autoconf-exception',
-      // 'GPL-3.0': 'GPL-3.0',
-      // 'GPL': 'NOASSERTION',
-      // 'mit': 'MIT',
-      // 'MIT ': 'MIT',
-      // ' MIT': 'MIT',
-      // 'GPL-1.0+': 'GPL-1.0+',
+      'AGPL-1.0': 'AGPL-1.0',
+      'apache-2.0': 'Apache-2.0',
+      'apache2': 'NOASSERTION',
+      'GPL-': 'NOASSERTION',
+      'GPL-2.0-with-autoconf-exception': 'GPL-2.0-with-autoconf-exception',
+      'GPL-3.0': 'GPL-3.0',
+      'GPL': 'NOASSERTION',
+      'mit': 'MIT',
+      'MIT ': 'MIT',
+      ' MIT': 'MIT',
+      'GPL-1.0+': 'GPL-1.0+',
       'OTHER': 'OTHER',
       'other': 'OTHER',
-      // 'Apache-2.0 WITH commons-clause': 'NOASSERTION',
-      // 'NOASSERTION': 'NOASSERTION',
-      // 'See license': 'NOASSERTION',
-      // 'MIT OR Apache-2.0': 'MIT OR Apache-2.0',
-      // 'MIT AND LGPL-2.1+ AND BSD-3-Clause': 'MIT AND LGPL-2.1+ AND BSD-3-Clause',
-      // '(MIT AND BSD-3-Clause WITH GCC-exception-3.1) OR (CC-BY-4.0 AND Apache-2.0)': 'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR CC-BY-4.0 AND Apache-2.0',
-      // 'MIT AND BSD-3-Clause AND CC-BY-4.0': 'MIT AND BSD-3-Clause AND CC-BY-4.0',
-      // 'MIT OR Junk': 'MIT OR NOASSERTION',
-      // 'mit OR Junk': 'MIT OR NOASSERTION',
-      // 'Commercial AND Apache-2.0': 'NOASSERTION AND Apache-2.0',
-      // 'Junk1 OR Junk 2': 'NOASSERTION',
-      // ' ': null,
-      // null: null
+      'Apache-2.0 WITH commons-clause': 'NOASSERTION',
+      'NOASSERTION': 'NOASSERTION',
+      'See license': 'NOASSERTION',
+      'MIT OR Apache-2.0': 'MIT OR Apache-2.0',
+      'MIT AND LGPL-2.1+ AND BSD-3-Clause': 'MIT AND LGPL-2.1+ AND BSD-3-Clause',
+      '(MIT AND BSD-3-Clause WITH GCC-exception-3.1) OR (CC-BY-4.0 AND Apache-2.0)': 'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR CC-BY-4.0 AND Apache-2.0',
+      'MIT AND BSD-3-Clause AND CC-BY-4.0': 'MIT AND BSD-3-Clause AND CC-BY-4.0',
+      'MIT OR Junk': 'MIT OR NOASSERTION',
+      'mit OR Junk': 'MIT OR NOASSERTION',
+      'Commercial AND Apache-2.0': 'NOASSERTION AND Apache-2.0',
+      'Junk1 OR Junk 2': 'NOASSERTION',
+      ' ': null,
+      null: null
     }
     for (let input of Object.keys(data)) {
       if (input === 'null') input = null


### PR DESCRIPTION
Clearly Defined accepts "OTHER" as a valid license, but it is not SPDX valid. We must include it as to fix the SPDX validation bug in Clearly Defined where declaring "OTHER" throws an error since it's not currently included in the list of valid licenses.