### PR TITLE
adds NONE as a valid license string

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const spdxSatisfies = require('spdx-satisfies')
 const spdxLicenseList = require('spdx-license-list')
 const spdxLicenseSet = require('spdx-license-list/simple')
 spdxLicenseSet.add('OTHER') // OTHER is a valid license in Clearly Defined, not found in SPDX
+spdxLicenseSet.add('NONE') // NONE is a valid license in Clearly Defined, not found in SPDX
 
 const lowerSpdxLicenseMap = new Map(Array.from(spdxLicenseSet).map(x => [x.toLowerCase(), x]))
 const lowerSpdxNameMap = new Map(Object.keys(spdxLicenseList).map(x => [spdxLicenseList[x].name.toLowerCase(), x]))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearlydefined/spdx",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "SPDX custom libraries of clearlydefined.io.",
   "license": "MIT",
   "repository": {

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ describe('SPDX utility functions', () => {
       ['MIT ', { license: 'MIT' }],
       [' MIT', { license: 'MIT' }],
       ['Other', { license: 'OTHER' }],
+      ['None', { license: 'NONE' }],
       ['MIT OR Apache-2.0', { left: { license: 'MIT' }, conjunction: 'or', right: { license: 'Apache-2.0' } }],
       ['MIT AND Apache-2.0', { left: { license: 'MIT' }, conjunction: 'and', right: { license: 'Apache-2.0' } }],
       [
@@ -204,6 +205,8 @@ describe('SPDX utility functions', () => {
       'GPL-1.0+': 'GPL-1.0+',
       'OTHER': 'OTHER',
       'other': 'OTHER',
+      'NONE': 'NONE',
+      'none': 'NONE',
       'Apache-2.0 WITH commons-clause': 'NOASSERTION',
       'NOASSERTION': 'NOASSERTION',
       'See license': 'NOASSERTION',


### PR DESCRIPTION
Builds on what was added in https://github.com/clearlydefined/spdx-expression-parse.js/pull/3

Signed-off-by: Nell Shamrell <nells@microsoft.com>