### PR TITLE
Publish package to github

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,23 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@clearlydefined'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -10,12 +10,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
-          # Defaults to the user or organization that owns the workflow file
           scope: '@clearlydefined'
       - run: npm ci
       - run: npm publish

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ This is used by [clearlydefined/service](https://github.com/clearlydefined/servi
 
 ## Install
 
+Package is hosted in GitHub packages
+See [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#installing-packages-from-other-organizations) for details on how to use
+
 ```
-npm install @clearlydefined/spdx
+npm install clearlydefined/spdx
 ```
 
 ```js
-const SPDX = require('@clearlydefined/spdx')
+const SPDX = require('spdx')
 
 SPDX.parse('MIT')
 SPDX.stringify({ license: 'MIT' })
@@ -33,16 +36,8 @@ npm test
 
 ## Release
 * Merge pull request to this repo (make sure that it updates the version of this package - similar to [this pull request](https://github.com/clearlydefined/spdx/pull/12).)
-* Release the new package to npm (the npm login credentials are in the ClearlyDefined Azure keyvault, if you need access or help with this reach out to @nellshamrell)
+* Create a relese on the Repository to run the [publish workflow](.github/workflows/publish-package.yml)
 
-```
-cd spdx
-git checkout master
-git fetch origin
-git rebase origin/master
-npm login
-npm publish
-```
 
-* Update [clearlydefined/service](https://github.com/clearlydefined/service) to use the new version (similar to [this pull request](https://github.com/clearlydefined/service/pull/832))
+* Update [clearlydefined/service](https://github.com/clearlydefined/service) to use the new version
 


### PR DESCRIPTION
# What

Adds Action to publish the node module to GitHub packages.

# Why

Getting access to the NPM account that this publishes to is difficult.
Putting on GitHub means package can be deployed easily by contributors with access the GitHub org and or repo.

Quick solution to unblock the service that depends on this pacakge