### PR TITLE
Migrate test.js to TypeScript ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '24.x'
+          node-version: "24.x"
       - run: npm ci
       - run: npm test
+      - run: npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,19 @@
       "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "spdx-expression-parse": "github:clearlydefined/spdx-expression-parse.js#fork",
-        "spdx-license-ids": "^3.0.21",
-        "spdx-license-list": "^6.10.0",
+        "spdx-license-ids": "3.0.23",
+        "spdx-license-list": "6.11.0",
         "spdx-satisfies": "github:clearlydefined/spdx-satisfies.js#parse-override"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.9",
-        "@tsconfig/node24": "^24.0.4",
-        "@types/lodash": "^4.17.24",
-        "typescript": "^6.0.2"
+        "@biomejs/biome": "2.4.10",
+        "@tsconfig/node24": "24.0.4",
+        "@tsconfig/strictest": "2.0.8",
+        "@types/lodash": "4.17.24",
+        "@types/node": "24.12.2",
+        "typescript": "6.0.2"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -192,12 +194,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tsconfig/strictest": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.8.tgz",
+      "integrity": "sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
@@ -283,6 +302,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,19 +20,21 @@
     "typecheck": "tsc",
     "format": "biome format --write .",
     "lint": "biome lint .",
-    "test": "node --test --experimental-test-coverage && biome check ."
+    "test": "node --test test.mts --experimental-test-coverage && biome check ."
   },
   "dependencies": {
-    "lodash": "^4.17.21",
+    "lodash": "4.18.1",
     "spdx-expression-parse": "github:clearlydefined/spdx-expression-parse.js#fork",
-    "spdx-license-ids": "^3.0.21",
-    "spdx-license-list": "^6.10.0",
+    "spdx-license-ids": "3.0.23",
+    "spdx-license-list": "6.11.0",
     "spdx-satisfies": "github:clearlydefined/spdx-satisfies.js#parse-override"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.9",
-    "@tsconfig/node24": "^24.0.4",
-    "@types/lodash": "^4.17.24",
-    "typescript": "^6.0.2"
+    "@biomejs/biome": "2.4.10",
+    "@tsconfig/node24": "24.0.4",
+    "@tsconfig/strictest": "2.0.8",
+    "@types/lodash": "4.17.24",
+    "@types/node": "24.12.2",
+    "typescript": "6.0.2"
   }
 }

--- a/test.mts
+++ b/test.mts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const SPDX = require('.')
-const { describe, it } = require('node:test')
-const assert = require('node:assert/strict')
-const { isDeepStrictEqual } = require('node:util')
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { isDeepStrictEqual } from 'node:util'
+import type { SpdxExpression } from './index.js'
+import SPDX from './index.js'
 
 describe('SPDX utility functions', () => {
   it('parses spdx expressions', () => {
-    const data = new Map([
+    const data = new Map<string | SpdxExpression, SpdxExpression>([
       [{ license: 'MIT' }, { license: 'MIT' }],
       ['MIT', { license: 'MIT' }],
       ['mit', { license: 'MIT' }],
@@ -211,7 +212,7 @@ describe('SPDX utility functions', () => {
       ]
     ])
 
-    const licenseRefLookup = identifier => {
+    const licenseRefLookup = (identifier: string) => {
       if (identifier === 'afpl-9.0') return 'LicenseRef-scancode-afpl-9.0'
       if (identifier === 'activestate-community') return 'LicenseRef-scancode-activestate-community'
       if (identifier === 'ac3filter') return 'LicenseRef-scancode-ac3filter'
@@ -224,7 +225,7 @@ describe('SPDX utility functions', () => {
   })
 
   it('stringifies spdx objects', () => {
-    const data = new Map([
+    const data = new Map<SpdxExpression, string>([
       [{ license: 'MIT' }, 'MIT'],
       [{ left: { license: 'MIT' }, conjunction: 'and', right: { license: 'Apache-2.0' } }, 'MIT AND Apache-2.0'],
       [{ left: { license: 'MIT' }, conjunction: 'or', right: { license: 'Apache-2.0' } }, 'MIT OR Apache-2.0'],
@@ -322,7 +323,7 @@ describe('SPDX utility functions', () => {
   })
 
   it('satisfies spdx expressions', () => {
-    const data = new Map([
+    const data = new Map<[string, string], boolean>([
       [['MIT', 'MIT'], true],
       [['mit', 'MIT'], true],
       [['MIT', 'mit'], true],
@@ -384,7 +385,7 @@ describe('SPDX utility functions', () => {
   })
 
   it('should expand expressions', () => {
-    const data = [
+    const data: [string, string[][]][] = [
       ['MIT', [['MIT']]],
       ['MIT AND GPL-3.0', [['GPL-3.0', 'MIT']]],
       ['MIT OR GPL-3.0', [['MIT'], ['GPL-3.0']]],
@@ -404,9 +405,9 @@ describe('SPDX utility functions', () => {
         ]
       ]
     ]
-    data.forEach(input => {
-      const results = SPDX.expand(input[0])
-      input[1].forEach(expected => {
+    data.forEach(([expression, expected]) => {
+      const results = SPDX.expand(expression)
+      expected.forEach(expected => {
         assert.ok(
           results.some(r => isDeepStrictEqual(r, expected)),
           `Expected ${JSON.stringify(results)} to deep-include ${JSON.stringify(expected)}`
@@ -451,9 +452,9 @@ describe('SPDX utility functions', () => {
       ' ': null,
       null: null
     }
-    for (let input of Object.keys(data)) {
-      if (input === 'null') input = null
-      assert.strictEqual(SPDX.normalize(input), data[input])
+    for (const key of Object.keys(data)) {
+      const input = key === 'null' ? null : key
+      assert.strictEqual(SPDX.normalize(input), data[key as keyof typeof data])
     }
   })
 
@@ -467,9 +468,9 @@ describe('SPDX utility functions', () => {
       ' ': null,
       null: null
     }
-    for (let input of Object.keys(data)) {
-      if (input === 'null') input = null
-      assert.strictEqual(SPDX.lookupByName(input), data[input])
+    for (const key of Object.keys(data)) {
+      const input = key === 'null' ? null : key
+      assert.strictEqual(SPDX.lookupByName(input), data[key as keyof typeof data])
     }
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": "@tsconfig/node24/tsconfig.json",
+  "extends": ["@tsconfig/strictest/tsconfig.json", "@tsconfig/node24/tsconfig.json"],
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["index.js", "index.d.ts"]
+  "include": ["index.js", "index.d.ts", "test.mts"]
 }


### PR DESCRIPTION
Converts test.js to test.mts so the test file is type-checked against the `.d.ts` declarations from #56. Also wires up `tsc` in CI so type errors don't slip through.

- Rename test.js -> test.mts, replace `require()` with ESM imports
- Add type annotations to test data (Map generics, tuples, callback params)
- Add `@tsconfig/strictest` and `@types/node` as dev dependencies
- Add `npm run typecheck` step to CI after `npm test`
- Pin dependency versions

Node 24 runs `.mts` directly via type stripping, so no build step or `tsx` needed. 

