### PR TITLE
Add missing @types for spdx deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "@tsconfig/strictest": "2.0.8",
         "@types/lodash": "4.17.24",
         "@types/node": "24.12.2",
+        "@types/spdx-expression-parse": "4.0.0",
+        "@types/spdx-license-ids": "3.0.0",
+        "@types/spdx-satisfies": "6.0.0",
         "typescript": "6.0.2"
       }
     },
@@ -217,6 +220,27 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-odQzy87phelGS4inXOzjmusx4hoCVD0IbxUANxHzVkmTzMRTNnUPoq1urIl7S1qf09KcDWKLFIftPmLtgbsAHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-x+bDiv6h46IR5lUipX/ndSWlOrwLxTFpTelLGRDcYm3vrELDaMpKFXIrIuxmpPl/I+IzMeOPBPWsribCFqmgBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/spdx-satisfies": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/spdx-satisfies/-/spdx-satisfies-6.0.0.tgz",
+      "integrity": "sha512-kOngOQzzhQrj4axuWWSWGzOO6MAe5eQ5qG3Zepe4LE/7lQJf7oYW8gAlNOywOhCpVY6oPs/YuJD463VdTk16ZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "@tsconfig/strictest": "2.0.8",
     "@types/lodash": "4.17.24",
     "@types/node": "24.12.2",
+    "@types/spdx-expression-parse": "4.0.0",
+    "@types/spdx-license-ids": "3.0.0",
+    "@types/spdx-satisfies": "6.0.0",
     "typescript": "6.0.2"
   }
 }


### PR DESCRIPTION
spdx-expression-parse, spdx-license-ids, and spdx-satisfies were missing their @types packages. Adds them as devDependencies.